### PR TITLE
build: remove manual .desktop file

### DIFF
--- a/wrench.desktop
+++ b/wrench.desktop
@@ -1,7 +1,0 @@
-[Desktop Entry]
-Type=Application
-Terminal=false
-Name=Wrench
-GenericName=Wrench
-Comment=Linux Configuration App
-Exec=wrench


### PR DESCRIPTION
This is automatically built now so its not needed.